### PR TITLE
Python2 incompatibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,20 @@ del _version
 
 # Loads _version.py module without importing the whole package.
 def get_version_and_cmdclass(package_name):
-    import os
-    from importlib.util import module_from_spec, spec_from_file_location
-    spec = spec_from_file_location('version',
-                                   os.path.join(package_name, '_version.py'))
-    module = module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module.__version__, module.cmdclass
+    try: # Python 3
+        from importlib.util import module_from_spec, spec_from_file_location
+        spec = spec_from_file_location('version',
+                                       os.path.join(package_name, "_version.py"))
+        module = module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module.__version__, module.cmdclass
+    except: # Python 2
+        import imp
+        module = imp.load_source(package_name.split('.')[-1], os.path.join(package_name, "_version.py"))
+        return module.__version__, module.cmdclass
 
 
-version, cmdclass = get_version_and_cmdclass('my_package')
+version, ver_cmdclass = get_version_and_cmdclass('mylibrary')
 
 setup(
     name='my_package',

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ def get_version_and_cmdclass(package_name):
         return module.__version__, module.cmdclass
     except: # Python 2
         import imp
-        module = imp.load_source(package_name.split('.')[-1], os.path.join(package_name, "_version.py"))
+        module = imp.load_source(package_name.split('.')[-1],
+                                 os.path.join(package_name, "_version.py"))
         return module.__version__, module.cmdclass
 
 

--- a/install-miniver
+++ b/install-miniver
@@ -29,15 +29,20 @@ _zipfile_root = 'miniver-master'  # tied to the fact that we fetch master.zip
 
 # File templates
 _setup_template = '''
-    # Loads version.py module without importing the whole package.
-    def get_version_and_cmdclass(package_path):
-        import os
-        from importlib.util import module_from_spec, spec_from_file_location
-        spec = spec_from_file_location('version',
-                                       os.path.join(package_path, '_version.py'))
-        module = module_from_spec(spec)
-        spec.loader.exec_module(module)
-        return module.__version__, module.cmdclass
+    # Loads _version.py module without importing the whole package.
+    def get_version_and_cmdclass(package_name):
+        try: # Python 3
+            from importlib.util import module_from_spec, spec_from_file_location
+            spec = spec_from_file_location('version',
+                                           os.path.join(package_name, "_version.py"))
+            module = module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module.__version__, module.cmdclass
+        except: # Python 2
+            import imp
+            module = imp.load_source(package_name.split('.')[-1],
+                                     os.path.join(package_name, "_version.py"))
+            return module.__version__, module.cmdclass
 
 
     version, cmdclass = get_version_and_cmdclass('{package_dir}')

--- a/miniver/_version.py
+++ b/miniver/_version.py
@@ -151,16 +151,20 @@ def _write_version(fname):
                 "version = '{}'\n".format(__version__))
 
 
-class _build(build_orig):
+# The following classes subclass `object` to become new-style classes with
+# Python 2; and calling super() with arguments is another workaround in order
+# to support Python 2.
+
+class _build(build_orig, object):
     def run(self):
-        super().run()
+        super(_build, self).run()
         _write_version(os.path.join(self.build_lib, package_name,
                                     STATIC_VERSION_FILE))
 
 
-class _sdist(sdist_orig):
+class _sdist(sdist_orig, object):
     def make_release_tree(self, base_dir, files):
-        super().make_release_tree(base_dir, files)
+        super(_sdist, self).make_release_tree(base_dir, files)
         _write_version(os.path.join(base_dir, package_name,
                                     STATIC_VERSION_FILE))
 

--- a/miniver/_version.py
+++ b/miniver/_version.py
@@ -44,10 +44,10 @@ def semver_format(version_info):
     if dev:
         if release.endswith('-dev'):
             version_parts.append(dev)
-        elif release.contains('-'):
+        elif '-' in release:
             version_parts.append('.dev{}'.format(dev))
         else:
-            version_parts.append('-dev{}'.format(dev))
+            version_parts.append('.dev{}'.format(dev))
 
     if labels:
         version_parts.append('+')
@@ -127,10 +127,10 @@ def get_version_from_git_archive(version_info):
     refs = set(r.strip() for r in refnames.split(","))
     version_tags = set(r[len(VTAG):] for r in refs if r.startswith(VTAG))
     if version_tags:
-        release, *_ = sorted(version_tags)  # prefer e.g. "2.0" over "2.0rc1"
+        release, _ = sorted(version_tags)  # prefer e.g. "2.0" over "2.0rc1"
         return Version(release, dev=None, labels=None)
     else:
-        return Version('unknown', dev=None, labels=[f'g{git_hash}'])
+        return Version('unknown', dev=None, labels=["{git_hash}".format(git_hash = git_hash)])
 
 
 __version__ = get_version()


### PR DESCRIPTION
Hi,

and many thanks for making miniver available! 

I started to use miniver in a project which is still based on python 2.17 and noticed a few incompatibilities in `_version.py`; basically the use of f-strings (in other places, the older `.format()` is however still used) as well as a `<unicode-string>.contains()`. They are however straightforward to fix and now it works beautifully in the older python as well (and under MacOS X, by the way).

I also turned a '-dev' component of the constructed version string into '.dev'; `setuptools` complained about the hyphen and made that replacement when using the version string.