### PR TITLE
add '--tags' option to 'git describe'

### DIFF
--- a/miniver/_version.py
+++ b/miniver/_version.py
@@ -4,7 +4,6 @@
 from collections import namedtuple
 import os
 import subprocess
-import sys
 
 from distutils.command.build_py import build_py as build_py_orig
 from setuptools.command.sdist import sdist as sdist_orig

--- a/miniver/_version.py
+++ b/miniver/_version.py
@@ -74,7 +74,7 @@ def get_version_from_git():
     # that were merged-in.
     for opts in [['--first-parent'], []]:
         try:
-            p = subprocess.Popen(['git', 'describe', '--long'] + opts,
+            p = subprocess.Popen(['git', 'describe', '--long', '--tags'] + opts,
                                  cwd=distr_root,
                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except OSError:


### PR DESCRIPTION
This seemed to be needed to get `minver` to work [here](https://github.com/instagrambot/instabot/pull/578/commits/8310434a5472cabc0867f9da02eabb5272274b3c).