### PR TITLE
Travis and Appveyor testing for OSX/Ubuntu/Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,37 @@
+environment:
+  matrix:
+    - PYTHON: C:\Python35-x64
+    - PYTHON: C:\Python36
+    - PYTHON: C:\Python36-x64
+    - PYTHON: C:\Python37
+    - PYTHON: C:\Python37-x64
+matrix:
+  fast_finish: true
+install:
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  # Git won't let us do anything without this.
+  - git config --global user.email "you@example.com"
+  - git config --global user.name "Your Name"
+  - "python --version"
+  - cd ..
+  - git init my_package
+  - cd my_package
+  - python ../miniver/ci/create_package.py
+  - git add .
+  - git commit -m "Initialization of package"
+  - git tag -a 0.0.0 -m "First version for miniver"
+  - pip install -e .
+
+# Not a .NET project
+build: false
+
+test_script:
+  - python -c "import my_package; assert my_package.__version__ == '0.0.0'
+  - cd ../my_package
+  - "echo # Extra comment >> setup.py"
+  - python -c "import my_package; assert my_package.__version__.endswith('dirty')"
+  - python -c "import my_package; assert my_package.__version__.startswith('0.0.0')"
+  - git commit -a -m "new comment"
+  - python -c "import my_package; assert my_package.__version__.startswith('0.0.0.dev1')"
+  - git tag -a 0.0.1 -m "0.0.1"
+  - python -c "import my_package; assert my_package.__version__ == '0.0.1'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,65 @@
+language: python
+
+matrix:
+  include:
+    - os: linux
+      python: 3.5
+    - os: linux
+      python: 3.6
+    - os: linux
+      python: 3.7
+      dist: xenial
+      sudo: true
+    - os: osx
+      language: generic
+      env: PYTHON=3.5.6
+    - os: osx
+      language: generic
+      env: PYTHON=3.6.6
+    - os: osx
+      language: generic
+      env: PYTHON=3.7.0
+
+# Taken from https://pythonhosted.org/CodeChat/.travis.yml.html#before-install
+before_install: |
+  if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    brew update
+    # Per the `pyenv homebrew recommendations <https://github.com/yyuu/pyenv/wiki#suggested-build-environment>`_.
+    brew install openssl readline
+    # See https://docs.travis-ci.com/user/osx-ci-environment/#A-note-on-upgrading-packages.
+    # I didn't do this above because it works and I'm lazy.
+    brew outdated pyenv || brew upgrade pyenv
+    # virtualenv doesn't work without pyenv knowledge. venv in Python 3.3
+    # doesn't provide Pip by default. So, use `pyenv-virtualenv <https://github.com/yyuu/pyenv-virtualenv/blob/master/README.md>`_.
+    brew install pyenv-virtualenv
+    pyenv install $PYTHON
+    # I would expect something like ``pyenv init; pyenv local $PYTHON`` or
+    # ``pyenv shell $PYTHON`` would work, but ``pyenv init`` doesn't seem to
+    # modify the Bash environment. ??? So, I hand-set the variables instead.
+    export PYENV_VERSION=$PYTHON
+    export PATH="/Users/travis/.pyenv/shims:${PATH}"
+    pyenv-virtualenv venv
+    source venv/bin/activate
+    # A manual check that the correct version of Python is running.
+    python --version
+  fi
+
+install:
+  - cd ..
+  - git init my_package
+  - cd my_package
+  - python ../miniver/ci/create_package.py
+  - git add .
+  - git commit -m 'Initialization of package'
+  - git tag -a 0.0.0 -m 'First version for miniver'
+  - pip install -e .
+script:
+  - python -c "import my_package; assert my_package.__version__ == '0.0.0'"
+  - cd ../my_package
+  - echo "# Extra comment" >> setup.py
+  - python -c "import my_package; assert my_package.__version__.endswith('dirty')"
+  - python -c "import my_package; assert my_package.__version__.startswith('0.0.0')"
+  - git commit -a -m 'new comment'
+  - python -c "import my_package; assert my_package.__version__.startswith('0.0.0.dev1')"
+  - git tag -a 0.0.1 -m '0.0.1'
+  - python -c "import my_package; assert my_package.__version__ == '0.0.1'"

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 **Like [versioneer][versioneer], but smaller**
 
 Miniver is a **mini**mal **ver**sioning tool that serves the same purpose
-as [Versioneer][versioneer], except that it is not designed to be
-cross platform, and only works with Git.
+as [Versioneer][versioneer], except that it only works with Git and
+multiplatform support is still experimental.
 
 #### Why would I use this?
 If you are developing a Python package inside a Git repository and
@@ -16,7 +16,8 @@ version strings everywhere.
 This is the same problem that Versioneer solves, but Miniver is less
 than 200 lines of code, whereas Versioneer is over 2000. The tradeoff
 is that Miniver only works with Git and Python 3.5 (or above), and has only been
-tested on Debian Linux and Mac OSX (so far).
+tested on Debian Linux and Mac OSX (automated with Travis) and for Windows
+on Appveyor.
 
 Support for Python 2 is not a goal, as Python 2 is fast approaching its
 end of life (2020), and we want to encourage people to use Python 3!

--- a/ci/create_package.py
+++ b/ci/create_package.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+from shutil import copyfile
+
+Path('my_package').mkdir(exist_ok=True)
+copyfile('../miniver/miniver/_static_version.py',
+         'my_package/_static_version.py')
+copyfile('../miniver/miniver/_version.py',
+         'my_package/_version.py')
+
+README_filename = '../miniver/README.md'
+
+def write_snippet_from_readme(outfile, start_marker, file_header=None):
+    # Create the setup file
+    with open(README_filename) as f:
+        for line in f:
+            if line.startswith(start_marker):
+                break
+        else:
+            raise RuntimeError('Could not find start_marker: {}'
+                               ''.format(start_marker))
+        with open(outfile, 'w') as out:
+            out.write(line)
+            if file_header is not None:
+                out.write(file_header)
+            for line in f:
+                if line.startswith('```'):
+                    break
+                out.write(line)
+
+write_snippet_from_readme("setup.py",
+                          "# Your project's setup.py",
+                          "from setuptools import setup\n")
+write_snippet_from_readme(".gitattributes",
+                          "# Your project's .gitattributes")
+write_snippet_from_readme("my_package/__init__.py",
+                          "# Your package's __init__.py")


### PR DESCRIPTION
Would you consider having Travis and Appveyor test this package automatically? I mostly pull things from the instructions in the README.md, so I test those too ;).

I've tested that this work:
https://github.com/hmaarrfk/miniver/pull/1

But you would need to sign up and enable Travis and Appveyor for your repo.

Your script actually works on windows, so I updated the Readme message.

We can add travis and appveyor badges too if you are so inclined.

Awesome stuff BTW.