### PR TITLE
Do not import from distutils

### DIFF
--- a/miniver/_version.py
+++ b/miniver/_version.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 import os
 import subprocess
 
-from distutils.command.build_py import build_py as build_py_orig
+from setuptools.command.build_py import build_py as build_py_orig
 from setuptools.command.sdist import sdist as sdist_orig
 
 Version = namedtuple("Version", ("release", "dev", "labels"))


### PR DESCRIPTION
According to the comment [1], we are adviced to use functions wrapped by
setuptools instead of distutils' raw ones.

Related problem is that setuptools-49.2.0 started to raise a warning, if
it sees that distutils is imported already. This *maybe* mitigates this
warning (if nothing imports distutils before

    from ._version import __version__

is called.

[1] https://github.com/pypa/setuptools/issues/2261#issuecomment-658315975