### PR TITLE
Remove use of f-strings to retain Python 3.5 compatibility

### DIFF
--- a/bin/miniver
+++ b/bin/miniver
@@ -204,13 +204,22 @@ def install(args):
 def ver(args):
     package_dir = args.package_directory
     try:
-        version_location, = glob.glob(f"{package_dir}/**/_version.py", recursive=True)
+        version_location, = glob.glob(
+            os.path.join(package_dir, "**", "_version.py"),
+            recursive=True,
+        )
     except ValueError as err:
         if "not enough" in str(err):
-            print(f"'_version.py' not found in '{package_dir}'", file=sys.stderr)
+            print(
+                "'_version.py' not found in '{}'".format(package_dir),
+                file=sys.stderr,
+            )
             sys.exit(1)
         elif "too many" in str(err):
-            print(f"More than 1 '_version.py' found in '{package_dir}'",  file=sys.stderr)
+            print(
+                "More than 1 '_version.py' found in '{}'".format(package_dir),
+                file=sys.stderr,
+            )
             sys.exit(1)
         else:
             raise


### PR DESCRIPTION
We may drop support for Python 3.5 in the future (it is already
past its end-of-life: https://endoflife.date/python), but for now
this is only a minor concession.