### PR TITLE
Changed how the generated version is triggered

### DIFF
--- a/bin/miniver
+++ b/bin/miniver
@@ -147,14 +147,6 @@ def get_parser():
         "package_directory", help="Directory to install 'miniver' into."
     )
     install_parser.set_defaults(dispatch=install)
-    # 'ver' command
-    ver_parser = subparsers.add_parser(
-        "ver", help="Get generated version"
-    )
-    ver_parser.add_argument(
-        "package_directory", help="Directory 'miniver' was installed."
-    )
-    ver_parser.set_defaults(dispatch=ver)
     return parser
 
 
@@ -202,22 +194,22 @@ def install(args):
 
 
 def ver(args):
-    package_dir = args.package_directory
+    cwd = os.path.abspath(".")
     try:
         version_location, = glob.glob(
-            os.path.join(package_dir, "**", "_version.py"),
+            os.path.join(cwd, "**", "_version.py"),
             recursive=True,
         )
     except ValueError as err:
         if "not enough" in str(err):
             print(
-                "'_version.py' not found in '{}'".format(package_dir),
+                "'_version.py' not found in '{}'".format(cwd),
                 file=sys.stderr,
             )
             sys.exit(1)
         elif "too many" in str(err):
             print(
-                "More than 1 '_version.py' found in '{}'".format(package_dir),
+                "More than 1 '_version.py' found in '{}'".format(cwd),
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -237,7 +229,8 @@ def main():
     if "dispatch" in args:
         args.dispatch(args)
     else:
-        parser.parse_args(["-h"])
+        args = argparse.Namespace(dispatch=ver)
+        args.dispatch(args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- removed `ver` as a subparser
- modified default behavior so that `miniver` with no arguments returns generated version
- removed package_directory and always assumes cwd

Resolves #31 and #32