### PR TITLE
Avoid `shell=True` with `subprocess` functions

### DIFF
--- a/ci/create_package.py
+++ b/ci/create_package.py
@@ -53,14 +53,13 @@ def main():
         rmtree(args.distribution, ignore_errors=True)
 
     with log("Initializing git repository in '{}'".format(distr)):
-        run("git init {}".format(distr), shell=True, check=True, stdout=PIPE, stderr=PIPE)
+        run("git init {}".format(distr), check=True, stdout=PIPE, stderr=PIPE)
         chdir(distr)
         makedirs(path)
 
     with log("Installing miniver in '{}'".format(os.path.join(distr, path))):
         r = run(
             "miniver install {}".format(path),
-            shell=True,
             check=True,
             stdout=PIPE,
             stderr=PIPE,


### PR DESCRIPTION
This is flagged as a security risk but code analysis tools such as DeepSource.io:
>	Using `shell=True` can expose you to security risks if someone
>	crafts input to issue different commands than the ones you intended.
>	[...]
>	It is recommended to use functions that don't spawn a shell.
>	If you must use them, use `shlex.quote` to sanitize the input.

See also:
	https://docs.python.org/3/library/subprocess.html#security-considerations