### PR TITLE
Use .post and not .dev

### DIFF
--- a/miniver/_version.py
+++ b/miniver/_version.py
@@ -48,7 +48,7 @@ def pep440_format(version_info):
         if release.endswith("-dev") or release.endswith(".dev"):
             version_parts.append(dev)
         else:  # prefer PEP440 over strict adhesion to semver
-            version_parts.append(".dev{}".format(dev))
+            version_parts.append(".post{}".format(dev))
 
     if labels:
         version_parts.append("+")


### PR DESCRIPTION
I think this is actually "correct" if you use tags. Since you are always working on the 'next thing'. 'dev' seems to imply that it is a working development release of the listed version.

This is at least true when people are using packaging instead of distutils.